### PR TITLE
Fixed Schwarzschild metric and removed leading order version of redshift

### DIFF
--- a/assignments/hw1.tex
+++ b/assignments/hw1.tex
@@ -60,7 +60,7 @@ Sun. In that case, $M$ is the total mass of the central object.
 M}{r c^2} \ll 1$.
 
 In this regime the Schwarzschild metric can be approximated to leading order as
-\footnote{This may not be immediately obvious, but a suitable change of coordinates leads to this form.}
+\footnote{It may not be immediately obvious, but a suitable change of coordinates leads to this form.}
 \begin{equation}
     \diff s^2 = - \left(1 + \frac{2 \Phi}{c^2}\right) c^2 \diff t^2
     + \left(1 - \frac{2 \Phi}{c^2}\right)
@@ -71,16 +71,16 @@ where we've identified the Newtonian potential $\Phi = -GM/r$.
 
 Find the equation of motion for a massive particle traveling in this field
 (Dodelson 2.3). You can use the fact that the particle is non-relativistic, so
-$p^0 \gg p^i$.
+$P^0 \gg P^i$.
 
 \paragraph{b)} Show that $\Gamma^0_{00} = c^{-3} \partial \Phi / \partial t$ and
 $\Gamma^i_{00} = c^{-2} \delta^{ij} \partial \Phi / \partial x^j$.
 
 \paragraph{c)} Show that the time component of the geodesic equation implies
-that energy $p^0 + m / c \Phi$ is conserved.
+that energy $P^0 + m \Phi / c$ is conserved.
 
 \paragraph{d)} Show that the space components of the geodesic equation lead to
-$\diff p^i / \diff t = - m \delta^{ij} \partial \Phi / \partial x^j$ in
+$\diff P^i / \diff t = - m \delta^{ij} \partial \Phi / \partial x^j$ in
 agreement with Newtonian theory.
 
 \section{Gravitational redshift}
@@ -142,8 +142,8 @@ perturbed metric given above:
 \paragraph{b)} Using the geodesic equation for the metric in
 Equation~\ref{eq:schwarz_pert}, show that the equation of motion for a \emph{photon} is to leading order
 \begin{equation}
-    \frac{\diff p_y}{\diff \lambda}
-    = \frac{2 M b}{\left(x^2 + b^2\right)^{3/2}} p_x^2 \text{ ,}
+    \frac{\diff P^y}{\diff \lambda}
+    = \frac{2 M b}{\left(x^2 + b^2\right)^{3/2}} (P^x)^2 \text{ ,}
 \end{equation}
 where $\lambda$ is an affine parameter for the geodesic.
 
@@ -155,10 +155,10 @@ deflection angle.
 \section{Redshift in the FRW metric}
 
 Consider a galaxy in the FRW metric located a large distance from an observer.
-The galaxy emits a photon at wavelength $\lambda_0$ in its inertial reference
-frame. When the photon reaches the observer, its measured wavelength is
-$\lambda_{obs}$. We fix the scale factor to be $a=1$ when the observer measures
-the photon, and $a=a_0$ when it was emitted.
+The galaxy emits a photon at wavelength $\lambda_e$ in its inertial reference
+frame at time $t_e$. When the photon reaches the observer, its measured
+wavelength is $\lambda_{r}$. We fix the scale factor to be $a=1$ when the
+observer measures the photon.
 
 \paragraph{a)} First, let's assume that the galaxy has no peculiar velocity with
 respect to the comoving frame defined by the metric. Recall that photons have
@@ -169,26 +169,26 @@ four-momentum
 where $E = hc / \lambda$, and an observer with four-velocity $U^\mu$ will
 measure their energy as
 \begin{equation}
-    E_R = g_{\mu \nu} U^\mu P^\nu \text{ .}
+    E_r = g_{\mu \nu} U^\mu P^\nu \text{ .}
 \end{equation}
 Using the fact that the photon travels along a
-geodesic, show that the observed wavelength is $\lambda_{obs} = \lambda_0 /
-a_0$.
+geodesic, show that the observed wavelength is $\lambda_{r} = \lambda_e /
+a(t_e)$.
 
 This relationship defines the redshift $z$
 \begin{equation}
-    \frac{\lambda_{obs}}{\lambda_0} = a_0^{-1} = 1 + z \text{ .}
+    \frac{\lambda_{r}}{\lambda_e} = \frac{1}{a(t_e)} = 1 + z \text{ .}
 \end{equation}
 
-\paragraph{b)} Writing a particles peculiar velocity as $v^i = d x^i / dt$ show that the time component of its four-velocity is
+\paragraph{b)} Writing a particle's peculiar velocity as $v^i = d x^i / dt$ show that the time component of its four-velocity is
 \begin{equation}
-    U^0 = (1 - a^2(t) v^i v_i)^{-1/2}
+    U^0 = \left(1 - a^2(t) \frac{v^i v_i}{c^2}\right)^{-1/2}
 \end{equation}
 and derive the remaining components.
 
 \paragraph{c)} Show that the full expression for the redshift seen by a comoving observer of a non-comoving galaxy in direction $\hat{\mathbf{n}}$ is
 \begin{equation}
-    \lambda_r = \lambda_e \: \frac{1}{a(t_e)} \: \left(1 + a(t_e) \hat{n}_i v^i \right) \: \frac{1}{\left(1 - a(t_e)^2 v^i v_i\right)^{1/2}}
+    \lambda_r = \lambda_e \: \frac{1}{a(t_e)} \: \left(1 + a(t_e) \frac{\hat{n}_i v^i}{c} \right) \: \frac{1}{\left(1 - a(t_e)^2 v^i v_i / c^2\right)^{1/2}}
 \end{equation}
 and interpret each term in the above expression.
 

--- a/assignments/hw1.tex
+++ b/assignments/hw1.tex
@@ -48,8 +48,9 @@ to
 A spherically symmetric spacetime is realised by the Schwarzschild metric:
 \begin{equation}
     \diff s^2 = - \left(1 - \frac{2 G M}{r c^2}\right) c^2 \diff t^2
-    + \left(1 - \frac{2 G M}{r c^2}\right)^{-1}
-    (\diff x^2 + \diff y^2 + \diff z^2) \text{ ,}
+    + \left(1 - \frac{2 G M}{r c^2}\right)^{-1} \diff r^2
+    + r^2 \diff \Omega^2 \text{ ,}
+\label{eq:schwarz}
 \end{equation}
 where $M$ is a constant. This metric describes the empty space on the outside of
 a compact spherical distribution of mass at the origin, like a black hole or the
@@ -59,6 +60,7 @@ Sun. In that case, $M$ is the total mass of the central object.
 M}{r c^2} \ll 1$.
 
 In this regime the Schwarzschild metric can be approximated to leading order as
+\footnote{This may not be immediately obvious, but a suitable change of coordinates leads to this form.}
 \begin{equation}
     \diff s^2 = - \left(1 + \frac{2 \Phi}{c^2}\right) c^2 \diff t^2
     + \left(1 - \frac{2 \Phi}{c^2}\right)
@@ -189,20 +191,5 @@ and derive the remaining components.
     \lambda_r = \lambda_e \: \frac{1}{a(t_e)} \: \left(1 + a(t_e) \hat{n}_i v^i \right) \: \frac{1}{\left(1 - a(t_e)^2 v^i v_i\right)^{1/2}}
 \end{equation}
 and interpret each term in the above expression.
-
-\paragraph{b)} If the galaxy possesses a velocity $\left|\mathbf{v}\right| \ll
-c$ relative to the comoving frame (where $\mathbf{v}$ is measured in comoving
-units), the photon will additionally be Doppler shifted. Show that to leading
-order the observed redshift will be offset by an amount
-\begin{equation}
-    \Delta z = a_0 \left(\frac{v_\parallel}{c}
-    - \frac{1}{2} \left(\frac{v_\perp}{c}\right)^2\right) \text{ ,}
-\end{equation}
-where $v_\parallel$ and $v_\perp$ are components of the velocity along and
-transverse to the line of sight, respectively.
-
-\textbf{Note for Richard:} I'm not sure about that factor of $a_0$. I think it
-shows up because I calculated the Doppler shift at the time of emission.
-
 
 \end{document}


### PR DESCRIPTION
I fixed the equation for the Schwarzschild metric and added a footnote addressing the fact that the relation between the two forms is not immediately obvious. It's clear though if you look at the form of the metric in isotropic coordinates: https://en.wikipedia.org/wiki/Schwarzschild_metric#Alternative_coordinates. There are also derivations of this in linearized gravity for a central mass. I don't think it's important to show the steps to convert between them, and we could also just omit providing the Schwarzschild metric, but I think it's nice to see the form of it.

I also deleted the last part of the redshift question since it's redundant now.

I was under the impression you were using c != 1 in the lectures, which is why I added the c's everywhere, but it's easy to remove them if that's not the case.